### PR TITLE
Disable scrolling

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -119,6 +119,7 @@ public class YouTubePlayerView: UIView, UIWebViewDelegate {
         webView.allowsInlineMediaPlayback = true
         webView.mediaPlaybackRequiresUserAction = false
         webView.delegate = self
+        webView.scrollView.scrollEnabled = false
     }
 
 


### PR DESCRIPTION
Since the video will just fill the frame, scrolling (in this case actually just bouncing) is unnecessary.