### PR TITLE
Include html files to pod source target

### DIFF
--- a/YouTubePlayer.podspec
+++ b/YouTubePlayer.podspec
@@ -1,13 +1,13 @@
 Pod::Spec.new do |s|
   s.name         = "YouTubePlayer"
-  s.version      = "0.2"
-  s.summary      = "Swift library for embedding and controlling YouTube videos in your iOS applications" 
+  s.version      = "0.2.2"
+  s.summary      = "Swift library for embedding and controlling YouTube videos in your iOS applications"
   s.homepage     = "https://github.com/gilesvangruisen/Swift-YouTube-Player"
   s.license      = { :type => "MIT", :file => "LICENSE" }
   s.author             = { "Giles Van Gruisen" => "giles@vangruisen.com" }
   s.social_media_url   = "http://twitter.com/gilesvangruisen"
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/gilesvangruisen/Swift-YouTube-Player.git", :tag => "v#{s.version}" }
-  s.source_files  = "YouTubePlayer/**/*.{swift,h,m}"
+  s.source_files  = "YouTubePlayer/**/*.{swift,h,m,html}"
   s.exclude_files = "Classes/Exclude"
 end


### PR DESCRIPTION
*This PR is related to https://github.com/gilesvangruisen/Swift-YouTube-Player/issues/24, but does not solve problem completely yet.*

Hi, thank you for a great library.

I realised YouTubePlayer.podspec 's `source_files` does not contain `html`.

So I fixed it and it works as expected, but still get `unexpectedly found nil while unwrapping an Optional value` fatal error.

I use CocoaPods with a Podfile below:

```ruby
# Podfile
platform :ios, '8.0'
use_frameworks!

pod 'YouTubePlayer', :git => 'https://github.com/ymkjp/Swift-YouTube-Player', :branch => 'feature/20150913_fix_podspec'
```

Thanks.