### PR TITLE
Add "origin" as possible Player Var

### DIFF
--- a/YouTubePlayer.podspec
+++ b/YouTubePlayer.podspec
@@ -8,7 +8,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/gilesvangruisen"
   s.platform     = :ios, "8.0"
   s.source       = { :git => "https://github.com/gilesvangruisen/Swift-YouTube-Player.git", :tag => "v#{s.version}" }
-  s.source_files  = "YouTubePlayer/**/*.{swift,h,m,html}"
+  s.source_files  = "YouTubePlayer/**/*.{swift,h,m}"
   s.exclude_files = "Classes/Exclude"
   s.resources = 'YouTubePlayer/**/*.html'
 end

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -207,8 +207,16 @@ public class YouTubePlayerView: UIView, UIWebViewDelegate {
         // Replace %@ in rawHTMLString with jsonParameters string
         let htmlString = rawHTMLString.stringByReplacingOccurrencesOfString("%@", withString: jsonParameters)
 
+        let baseURL: NSURL
+        if let origin = parameters["origin"],
+            let originURL = NSURL(origin) {
+                baseURL = originURL
+        } else {
+            baseURL = NSURL(string: "about:blank")
+        }
+        
         // Load HTML in web view
-        webView.loadHTMLString(htmlString, baseURL: NSURL(string: "about:blank"))
+        webView.loadHTMLString(htmlString, baseURL: baseURL)
     }
 
     private func playerHTMLPath() -> String {

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -207,9 +207,10 @@ public class YouTubePlayerView: UIView, UIWebViewDelegate {
         // Replace %@ in rawHTMLString with jsonParameters string
         let htmlString = rawHTMLString.stringByReplacingOccurrencesOfString("%@", withString: jsonParameters)
 
-        let baseURL: NSURL
-        if let origin = parameters["origin"],
-            let originURL = NSURL(origin) {
+        let baseURL: NSURL?
+        if  let playerVars = parameters["playerVars"] as? YouTubePlayerParameters,
+            let origin = playerVars["origin"] as? String,
+            let originURL = NSURL(string: origin) {
                 baseURL = originURL
         } else {
             baseURL = NSURL(string: "about:blank")


### PR DESCRIPTION
Most of embeddable video, notably the ones from Vevo, cannot be played is the "_origin_" is missed.
This PR gives the chance to add an optional "origin" parameters to define it.
The official YouTube iOS pod has a similar implementation:
https://github.com/youtube/youtube-ios-player-helper/blob/master/Classes/YTPlayerView.m#L722
