### PR TITLE
Fix crash when parsing URLs with GET parameters without value

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -61,7 +61,9 @@ private extension NSURL {
 
                 // Pull key, val from from pair parts (separated by =) and set dict[key] = value
                 let components = pair.componentsSeparatedByString("=")
-                dict[components[0]] = components[1]
+                if (components.count > 1) {
+                    dict[components[0]] = components[1]
+                }
             }
 
         }


### PR DESCRIPTION
I've been receiving some crash reports for an app I'm developing and a subsequent investigation revealed that happened attempting to play YouTube videos whose URLs contain valueless GET parameters results in a crash when parsing the URL.

Here's an example: https://www.youtube.com/watch?v=yhnkD7YxJ1s&feature=youtu.be&a 

It all boils down to the fact that the lib assumes every parameter has a specific value, although it may not be the case.