### PR TITLE
Remove initial white flash on iOS10

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -128,6 +128,8 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
     
     fileprivate func buildWebView(_ parameters: [String: AnyObject]) {
         webView = UIWebView()
+        webView.isOpaque = false
+        webView.backgroundColor = UIColor.clear
         webView.allowsInlineMediaPlayback = true
         webView.mediaPlaybackRequiresUserAction = false
         webView.delegate = self


### PR DESCRIPTION
@gilesvangruisen can you please take a look? It is a quick UI fix to remove the white initial flashing when the video start loading 