### PR TITLE
fix crash on subclassing of YouTubePlayerView

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -233,7 +233,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
     }
     
     fileprivate func playerHTMLPath() -> String {
-        return Bundle(for: self.classForCoder).path(forResource: "YTPlayer", ofType: "html")!
+        return Bundle(for: YouTubePlayerView.self).path(forResource: "YTPlayer", ofType: "html")!
     }
     
     fileprivate func htmlStringWithFilePath(_ path: String) -> String? {


### PR DESCRIPTION
When I created a subclass of `YouTubePlayerView`, and the `func loadVideoURL` function, the loading of the index file was crashed because it was looked for the wrong module (self.classForCoder pointed to the Bundle of my actual project instead of the YouTubePlayerView's bundle). This results a crash at least when we installing using Cocoapod. 