### PR TITLE
Add origin URL support

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -97,7 +97,11 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
     
     /** Used to configure the player */
     open var playerVars = YouTubePlayerParameters()
-    
+
+    /** Option to sepcify your domain. More info check: https://developers.google.com/youtube/player_parameters#Manual_IFrame_Embeds.
+     This is also a solution how to get access some videos restricted on mobile: http://stackoverflow.com/a/31060173/1545278 */
+    open var originURL: URL?
+
     /** Used to respond to player events */
     open weak var delegate: YouTubePlayerDelegate?
     
@@ -229,7 +233,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
         let htmlString = rawHTMLString.replacingOccurrences(of: "%@", with: jsonParameters)
         
         // Load HTML in web view
-        webView.loadHTMLString(htmlString, baseURL: URL(string: "about:blank"))
+        webView.loadHTMLString(htmlString, baseURL: (originURL != nil) ? originURL : URL(string: "about:blank"))
     }
     
     fileprivate func playerHTMLPath() -> String {

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -233,7 +233,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
     }
     
     fileprivate func playerHTMLPath() -> String {
-        return Bundle(for: self.classForCoder).path(forResource: "YTPlayer", ofType: "html")!
+        return Bundle(for: YouTubePlayerView.self).path(forResource: "YTPlayer", ofType: "html")!
     }
     
     fileprivate func htmlStringWithFilePath(_ path: String) -> String? {


### PR DESCRIPTION
I was not able to play some video in my iOS app, and the inspiration of the fix is comming from here:
http://stackoverflow.com/a/31060173/1545278

Now I can specify my domain as `origin`, as it is described in the Youtube Player API: https://developers.google.com/youtube/player_parameters#Manual_IFrame_Embeds.

@gilesvangruisen 