### PR TITLE
Issue #102: Fixes 'Result of call to 'evaluatePlayerCommand' is unused' warning in xCode 9

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -212,7 +212,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
         evaluatePlayerCommand("nextVideo()")
     }
     
-    fileprivate func evaluatePlayerCommand(_ command: String) -> String? {
+    @discardableResult fileprivate func evaluatePlayerCommand(_ command: String) -> String? {
         let fullCommand = "player." + command + ";"
         return webView.stringByEvaluatingJavaScript(from: fullCommand)
     }


### PR DESCRIPTION
implements solution provided by DavideCan at
https://github.com/gilesvangruisen/Swift-YouTube-Player/issues/102