### PR TITLE
Removing swift 3/4 warnings

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -212,7 +212,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
         evaluatePlayerCommand("nextVideo()")
     }
     
-    fileprivate func evaluatePlayerCommand(_ command: String) -> String? {
+    @discardableResult fileprivate func evaluatePlayerCommand(_ command: String) -> String? {
         let fullCommand = "player." + command + ";"
         return webView.stringByEvaluatingJavaScript(from: fullCommand)
     }
@@ -286,7 +286,7 @@ open class YouTubePlayerView: UIView, UIWebViewDelegate {
             let jsonData = try JSONSerialization.data(withJSONObject: object, options: JSONSerialization.WritingOptions.prettyPrinted)
             
             // Succeeded
-            return NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue) as? String
+            return NSString(data: jsonData, encoding: String.Encoding.utf8.rawValue) as String?
             
         } catch let jsonError {
             


### PR DESCRIPTION
Fixes #138 and #102 

Used @discardableResult approach, since most player's commands are discardable.

`NSString? as? String`  is the same as `NSString? as String?`, since the NSString to String conversion is guaranteed. 