### PR TITLE
add swift_version to podspec

### DIFF
--- a/YouTubePlayer.podspec
+++ b/YouTubePlayer.podspec
@@ -7,6 +7,7 @@ Pod::Spec.new do |s|
   s.author             = { "Giles Van Gruisen" => "giles@vangruisen.com" }
   s.social_media_url   = "http://twitter.com/gilesvangruisen"
   s.platform     = :ios, "8.0"
+  s.swift_version = '4.2'
   s.source       = { :git => "https://github.com/gilesvangruisen/Swift-YouTube-Player.git", :tag => "v#{s.version}" }
   s.source_files  = "YouTubePlayer/**/*.{swift,h,m}"
   s.exclude_files = "Classes/Exclude"


### PR DESCRIPTION
Fix podspec:

```
$ pod lib lint

 -> YouTubePlayer (0.5.0)
    - NOTE  | xcodebuild:  note: Using new build system
    - NOTE  | [iOS] xcodebuild:  note: Planning build
    - NOTE  | [iOS] xcodebuild:  note: Constructing build description
    - NOTE  | [iOS] xcodebuild:  warning: Skipping code signing because the target does not have an Info.plist file. (in target 'App')

YouTubePlayer passed validation.
```