### PR TITLE
Add Support for the Swift Package Manager

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@
 .DS_Store
 */build/*
 build/*
+*/.build/*
+.build/*
 *.pbxuser
 !default.pbxuser
 *.mode1v3

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,30 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "YouTubePlayer",
+    platforms: [.iOS(.v13)],
+    products: [
+        .library(name: "YouTubePlayer",
+                 targets: ["YouTubePlayer"])
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "YouTubePlayer",
+            dependencies: [],
+            path: "YouTubePlayer/YouTubePlayer",
+            exclude: ["Info.plist"],
+            resources: [
+                .process("YTPlayer.html")
+            ]
+        ),
+        .testTarget(
+            name: "YouTubePlayerTests",
+            dependencies: ["YouTubePlayer"],
+            path: "YouTubePlayer/Tests/YouTubePlayerTests"
+        )
+    ]
+)

--- a/YouTubePlayer.xcworkspace/contents.xcworkspacedata
+++ b/YouTubePlayer.xcworkspace/contents.xcworkspacedata
@@ -2,6 +2,9 @@
 <Workspace
    version = "1.0">
    <FileRef
+      location = "group:Package.swift">
+   </FileRef>
+   <FileRef
       location = "container:YouTubePlayer/YouTubePlayer.xcodeproj">
    </FileRef>
    <FileRef

--- a/YouTubePlayer/Tests/YouTubePlayerTests/YouTubePlayerTests.swift
+++ b/YouTubePlayer/Tests/YouTubePlayerTests/YouTubePlayerTests.swift
@@ -1,0 +1,33 @@
+//
+//  YouTubePlayerTests.swift
+//  YouTubePlayer
+//
+//  Created by Marcel on 04.03.21.
+//  Copyright © 2021 Giles Van Gruisen. All rights reserved.
+//
+
+import XCTest
+
+class YouTubePlayerTests: XCTestCase {
+
+    override func setUpWithError() throws {
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+
+    override func tearDownWithError() throws {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+    }
+
+    func testExample() throws {
+        // This is an example of a functional test case.
+        // Use XCTAssert and related functions to verify your tests produce the correct results.
+    }
+
+    func testPerformanceExample() throws {
+        // This is an example of a performance test case.
+        self.measure {
+            // Put the code you want to measure the time of here.
+        }
+    }
+
+}

--- a/YouTubePlayer/YouTubePlayer.xcodeproj/project.pbxproj
+++ b/YouTubePlayer/YouTubePlayer.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		50E5B9C91A4CAA050099BF69 /* YTPlayer.html in Resources */ = {isa = PBXBuildFile; fileRef = 50E5B9C81A4CAA050099BF69 /* YTPlayer.html */; };
 		50E5B9CB1A4CAA150099BF69 /* YouTubePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 50E5B9CA1A4CAA150099BF69 /* YouTubePlayer.swift */; };
+		E616AC7A25F0BBC200AAE4E2 /* YouTubePlayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E616AC7925F0BBC200AAE4E2 /* YouTubePlayerTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -16,6 +17,7 @@
 		502AE8631A475FD500306AD1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; name = Info.plist; path = YouTubePlayer/Info.plist; sourceTree = "<group>"; };
 		50E5B9C81A4CAA050099BF69 /* YTPlayer.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; name = YTPlayer.html; path = YouTubePlayer/YTPlayer.html; sourceTree = SOURCE_ROOT; };
 		50E5B9CA1A4CAA150099BF69 /* YouTubePlayer.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; name = YouTubePlayer.swift; path = YouTubePlayer/YouTubePlayer.swift; sourceTree = SOURCE_ROOT; };
+		E616AC7925F0BBC200AAE4E2 /* YouTubePlayerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = YouTubePlayerTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -32,6 +34,7 @@
 		502AE8551A475FD500306AD1 = {
 			isa = PBXGroup;
 			children = (
+				E616AC7725F0BB8800AAE4E2 /* Tests */,
 				502AE8611A475FD500306AD1 /* YouTubePlayer */,
 				502AE8601A475FD500306AD1 /* Products */,
 			);
@@ -62,6 +65,22 @@
 				502AE8631A475FD500306AD1 /* Info.plist */,
 			);
 			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		E616AC7725F0BB8800AAE4E2 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				E616AC7825F0BB9600AAE4E2 /* YouTubePlayerTests */,
+			);
+			path = Tests;
+			sourceTree = "<group>";
+		};
+		E616AC7825F0BB9600AAE4E2 /* YouTubePlayerTests */ = {
+			isa = PBXGroup;
+			children = (
+				E616AC7925F0BBC200AAE4E2 /* YouTubePlayerTests.swift */,
+			);
+			path = YouTubePlayerTests;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -145,6 +164,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				E616AC7A25F0BBC200AAE4E2 /* YouTubePlayerTests.swift in Sources */,
 				50E5B9CB1A4CAA150099BF69 /* YouTubePlayer.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -253,7 +253,7 @@ open class YouTubePlayerView: UIView, WKNavigationDelegate {
     }
 
     fileprivate func playerHTMLPath() -> String {
-        return Bundle(for: YouTubePlayerView.self).path(forResource: "YTPlayer", ofType: "html")!
+        return Bundle.module.path(forResource: "YTPlayer", ofType: "html")!
     }
 
     fileprivate func htmlStringWithFilePath(_ path: String) -> String? {

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -6,6 +6,7 @@
 //  Copyright (c) 2014 Giles Van Gruisen. All rights reserved.
 //
 
+#if canImport(UIKit)
 import UIKit
 import WebKit
 
@@ -376,3 +377,4 @@ private func printLog(_ strings: CustomStringConvertible...) {
     let toPrint = ["[YouTubePlayer]"] + strings
     print(toPrint, separator: " ", terminator: "\n")
 }
+#endif


### PR DESCRIPTION
Since SPM supports Resource processing in its newer version, I was able to add Support to SPM for your Framework.
I've tested everything through the command `swift test` and resolved every Error.

To Support the loading of the `YTPlayer.html` it was necessary to implement the `Bundle.module` instead of the `Bundle(for: YouTubePlayerView.self)` which would lead to a crash while running an application with the YouTubePlayer.

The Tests are just added to satisfy the command line tool so I haven't implemented any tests. 

I've uploaded a little test application to prove that the SPM Support is working. There also is a simple SwiftUI Example integrated.
https://github.com/vincentthe0ne/SPMYouTubePlayerTest

With this MR the #215 will be solved.