### PR TITLE
fix: unavailable video when video is available

### DIFF
--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -34,7 +34,7 @@ public enum YouTubePlaybackQuality: String {
     case HighResolution = "highres"
 }
 
-public protocol YouTubePlayerDelegate: class {
+public protocol YouTubePlayerDelegate: AnyObject {
     func playerReady(_ videoPlayer: YouTubePlayerView)
     func playerStateChanged(_ videoPlayer: YouTubePlayerView, playerState: YouTubePlayerState)
     func playerQualityChanged(_ videoPlayer: YouTubePlayerView, playbackQuality: YouTubePlaybackQuality)
@@ -86,7 +86,7 @@ public func videoIDFromYouTubeURL(_ videoURL: URL) -> String? {
 open class YouTubePlayerView: UIView, WKNavigationDelegate {
 
     public typealias YouTubePlayerParameters = [String: AnyObject]
-    public var baseURL = "about:blank"
+    public var baseURL = "https://www.youtube.com"
 
     fileprivate var webView: WKWebView!
 


### PR DESCRIPTION
This pr fix a potential bug when a video is available and the container view says a unavailable video.