### PR TITLE
update User agent

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,3 +100,7 @@ you will need to replace any call to either `getCurrentTime()` and
 `getDuration()` with its asynchronous equivalent, [documented
 above](#controlling-youtubeplayerview).
 
+**0.7.3**
+Now, We can change `WKWebView`'s userAgent.
+(Some video can't played in iOS WebView, so change userAgent to Desktop)
+

--- a/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
+++ b/YouTubePlayer/YouTubePlayer/YouTubePlayer.swift
@@ -143,6 +143,9 @@ open class YouTubePlayerView: UIView, WKNavigationDelegate {
         webView.scrollView.isScrollEnabled = false
     }
 
+    open func changeUserAgent(_ userAgent: String) {
+        webView.customUserAgent = userAgent
+    }
 
     // MARK: Load player
 


### PR DESCRIPTION
In iOS's WKWebView, some videos can't be played.
The solution is to change the WKWebView's UserAgent.